### PR TITLE
Fix imports and add requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 aioredis==1.3.1
-click==7.1.2
 msgpack==1.0.0
 pydantic==1.5.1
 uvicorn==0.11.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+aioredis==1.3.1
+click==7.1.2
+msgpack==1.0.0
+pydantic==1.5.1
+uvicorn==0.11.5


### PR DESCRIPTION
Hey, I found missing imports in `tino.py`. It seems that method which has it it not used in project but I don't know what is your idea for that so I keep this method with fixed imports. Also unused imports are deleted.

Furthermore I added `requirements.txt` file. I think will be easier for developers because for now requires are only in `setup.py`.